### PR TITLE
Added Kite MCP setup instructions for VS Code on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,62 @@ If you want to use the hosted version, you can use the following config:
 }
 ```
 
+## VS Code Setup
+
+### Prerequisites
+
+- Visual Studio Code installed ([download](https://code.visualstudio.com/download)).
+- Node.js installed (version 18 or higher is recommended). You can download it from https://nodejs.org. (Note: older versions might cause issues, as seen in user feedback on the blog).
+- VS Code GitHub Copilot extension installed and authenticated with your GitHub account. ([link](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot))
+
+### Configuration Steps for macOS
+
+1. Open VS Code.
+2. Open the Command Palette using `Cmd+Shift+P`.
+3. Type "Preferences: Open User Settings (JSON)" and select it to open your `settings.json` file.
+4. Add the following JSON configuration to your `settings.json` file. If you already have existing settings, add this as a new top-level entry, ensuring you place a comma appropriately if needed to keep the JSON valid:
+   ```json
+   "mcp": {
+       "inputs": [],
+       "servers": {
+           "kite": {
+               "url": "https://mcp.kite.trade/sse"
+           }
+       }
+   }
+   ```
+   (Note: Ensure that the quotes are standard double quotes (`"`) and not curly quotes (`“”`), as curly quotes will cause parsing errors. Also, ensure the URL is `https://` and not `http://`.)
+5. Save the `settings.json` file.
+6. Restart Visual Studio Code for the changes to take effect.
+7. Open the GitHub Copilot Chat panel (you can usually find this in the sidebar or by searching for "Copilot Chat" in the Command Palette).
+8. In the chat input, type `/mcp` and press Enter. You should see "kite" listed as an available MCP server. This command helps verify that the MCP server is recognized by the Copilot extension.
+9. If prompted, follow the on-screen instructions to authorize your Zerodha account. This will typically involve logging in to your Kite account through a browser window opened by VS Code.
+
+### Troubleshooting
+
+*   **Error: `MCP kite: Server disconnected` or `Could not attach to MCP server kite` or `session not found`**
+    *   **Node.js Version:** Ensure you have Node.js version 18 or higher installed. You can check your version by opening a terminal and typing `node --version`. If it's lower than 18, please upgrade from [https://nodejs.org](https://nodejs.org).
+    *   **Check `settings.json`:**
+        *   Verify that the JSON in your `settings.json` file is correct. Pay close attention to commas (especially if you added the MCP config next to existing settings) and ensure you've used standard double quotes (`"`) for all keys and string values, not curly quotes (`“”`).
+        *   Ensure the URL is exactly `https://mcp.kite.trade/sse`. Using `http://` will not work.
+    *   **Restart VS Code:** Make sure you've restarted VS Code after making changes to `settings.json`.
+    *   **Re-authenticate:** Try typing `/mcp` in the Copilot chat. If Kite is listed, try selecting it. It might prompt for re-authentication. Sometimes, the session might expire, and you might need to log in to Kite again.
+    *   **Check for Conflicting Extensions:** While rare, another extension could potentially interfere. Try temporarily disabling other extensions related to chat or AI to see if that resolves the issue.
+
+*   **Error related to `npx` not found or `spawn npx ENOENT` (this might appear in VS Code's logs or if trying to run mcp-remote manually for debugging)**
+    *   **Node.js Installation:** `npx` is part of Node.js (npm). Ensure Node.js is installed correctly and that its installation directory (usually something like `C:\Program Files\nodejs` on Windows or `/usr/local/bin` on macOS/Linux) is included in your system's PATH environment variable. You can verify by opening a new terminal/command prompt and typing `npx --version`. If it doesn't show a version, your PATH is likely not configured correctly for Node.js.
+    *   **Restart VS Code/Terminal:** After installing Node.js or modifying PATH, restart VS Code and any terminal windows.
+
+*   **`/mcp` command not working or not showing Kite in Copilot Chat**
+    *   **Copilot Extension:** Ensure the GitHub Copilot extension (and specifically GitHub Copilot Chat) is enabled and properly authenticated. Check for any error notifications from the Copilot extension itself.
+    *   **Correct `settings.json` Entry:** Double-check that the `"mcp"` configuration is correctly placed in your `settings.json` file and that the file was saved.
+    *   **VS Code Version:** Ensure your VS Code is updated to a recent version, as MCP support in extensions might depend on newer VS Code APIs.
+
+*   **JSON Parsing Errors (e.g., "Error reading or parsing settings.json")**
+    *   This is almost always due to a syntax error in your `settings.json` file.
+    *   Carefully check for missing or extra commas, incorrect quote types (use `"` not `“”`), or mismatched brackets (`{}`).
+    *   You can use an online JSON validator to check the syntax of your `settings.json` content if you're unsure.
+
 ## Kite Connect API Integration Status
 
 | API Method                   | Integration Status | Remarks                                         |


### PR DESCRIPTION
This update includes a new section in the README.md file, offering detailed, step-by-step guidance for setting up the Kite MCP server in Visual Studio Code on macOS with GitHub Copilot.

The new section covers:
- Prerequisites for the setup.
- Configuration steps, including how to edit settings.json and the necessary JSON configuration.
- Troubleshooting tips for common issues you might encounter.