### PR TITLE
Replace struct initialization with mcp convinience method

### DIFF
--- a/mcp/get_tools.go
+++ b/mcp/get_tools.go
@@ -41,14 +41,7 @@ func (*ProfileTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		profileJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: profileJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(profileJSON), nil
 	}
 }
 
@@ -83,14 +76,7 @@ func (*MarginsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		marginsJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: marginsJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(marginsJSON), nil
 	}
 }
 
@@ -148,14 +134,7 @@ func (*HoldingsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		holdingsJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: holdingsJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(holdingsJSON), nil
 	}
 }
 
@@ -190,14 +169,7 @@ func (*PositionsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		positionsJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: positionsJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(positionsJSON), nil
 	}
 }
 
@@ -232,14 +204,7 @@ func (*TradesTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		tradesJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: tradesJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(tradesJSON), nil
 	}
 }
 
@@ -274,14 +239,7 @@ func (*OrdersTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		ordersJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: ordersJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(ordersJSON), nil
 	}
 }
 
@@ -316,13 +274,6 @@ func (*GTTOrdersTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		gttBookJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: gttBookJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(gttBookJSON), nil
 	}
 }

--- a/mcp/market_tools.go
+++ b/mcp/market_tools.go
@@ -56,14 +56,7 @@ func (*QuotesTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		quotesJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: quotesJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(quotesJSON), nil
 	}
 }
 
@@ -143,14 +136,7 @@ func (*InstrumentsSearchTool) Handler(manager *kc.Manager) server.ToolHandlerFun
 		}
 
 		instrumentsJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: instrumentsJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(instrumentsJSON), nil
 	}
 }
 
@@ -248,13 +234,6 @@ func (*HistoricalDataTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		historicalDataJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: historicalDataJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(historicalDataJSON), nil
 	}
 }

--- a/mcp/mf_tools.go
+++ b/mcp/mf_tools.go
@@ -41,13 +41,6 @@ func (*MFHoldingsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		holdingsJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: holdingsJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(holdingsJSON), nil
 	}
 }

--- a/mcp/post_tools.go
+++ b/mcp/post_tools.go
@@ -126,14 +126,7 @@ func (*PlaceOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		ordersRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: ordersRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(ordersRespJSON), nil
 	}
 }
 
@@ -215,14 +208,7 @@ func (*ModifyOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		ordersRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: ordersRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(ordersRespJSON), nil
 	}
 }
 
@@ -272,14 +258,7 @@ func (*CancelOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		ordersRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: ordersRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(ordersRespJSON), nil
 	}
 }
 
@@ -406,14 +385,7 @@ func (*PlaceGTTOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		gttRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: gttRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(gttRespJSON), nil
 	}
 }
 
@@ -458,14 +430,7 @@ func (*DeleteGTTOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		gttRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: gttRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(gttRespJSON), nil
 	}
 }
 
@@ -599,13 +564,6 @@ func (*ModifyGTTOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		gttRespJSON := string(v)
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.TextContent{
-					Type: "text",
-					Text: gttRespJSON,
-				},
-			},
-		}, nil
+		return mcp.NewToolResultText(gttRespJSON), nil
 	}
 }


### PR DESCRIPTION
This PR updates how `mcp.CallToolResult` is initialized, switching from direct struct initialization to using the `mcp.NewToolResultText` convenience method.


Sidenote - This was done using the following regex on vscode -
SEARCH - `&mcp\.CallToolResult\{
			Content: \[\]mcp\.Content\{
				mcp\.TextContent\{
					Type: "text",
					Text: (.*),
				\},
			\},`
REPLACE - `mcp.NewToolResultText($1)`

![Screenshot 2025-05-25 at 19 07 39](https://github.com/user-attachments/assets/782bfec8-ec16-4c79-a0ad-a7f3d5c09b58)
