### PR TITLE
feat: Improved security by hashing the session ID with HMAC-SHA256 before sending it to the login URL

### DIFF
--- a/kc/manager.go
+++ b/kc/manager.go
@@ -79,7 +79,6 @@ func (m *Manager) ClearSession(sessionID string) {
 	hashedID := hashSessionID(sessionID, m.apiSecret)
 	if sess, ok := m.Sessions[hashedID]; ok {
 		sess.Kite.Client.InvalidateAccessToken()
-		delete(m.Sessions, sessionID)
 		delete(m.Sessions, hashedID)
 	}
 }


### PR DESCRIPTION
Key Changes:

- Improved security by hashing the session ID in `kc/manager.go` with HMAC-SHA256 before sending it to the login URL. Calls to session handling functions now use the hashed ID, ensuring the plain session ID isn’t exposed.
- Introduced `hashSessionID` and use hashed IDs across session management methods.