### PR TITLE
enh: add annotations to mcp tools

### DIFF
--- a/mcp/get_tools.go
+++ b/mcp/get_tools.go
@@ -13,6 +13,7 @@ type ProfileTool struct{}
 func (*ProfileTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_profile",
 		mcp.WithDescription("Retrieve the user's profile information, including user ID, name, email, and account details like products orders, and exchanges available to the user. Use this to get basic user details."),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -27,6 +28,7 @@ type MarginsTool struct{}
 func (*MarginsTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_margins",
 		mcp.WithDescription("Get margins"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -47,6 +49,7 @@ func (*HoldingsTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of holdings to return. If not specified, returns all holdings. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -77,6 +80,7 @@ func (*PositionsTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of positions to return. If not specified, returns all positions. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -113,6 +117,7 @@ func (*TradesTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of trades to return. If not specified, returns all trades. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -143,6 +148,7 @@ func (*OrdersTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of orders to return. If not specified, returns all orders. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -173,6 +179,7 @@ func (*GTTOrdersTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of GTT orders to return. If not specified, returns all GTT orders. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -201,6 +208,7 @@ func (*OrderTradesTool) Tool() mcp.Tool {
 			mcp.Description("ID of the order to fetch trades for"),
 			mcp.Required(),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -237,6 +245,7 @@ func (*OrderHistoryTool) Tool() mcp.Tool {
 			mcp.Description("ID of the order to fetch history for"),
 			mcp.Required(),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 

--- a/mcp/market_tools.go
+++ b/mcp/market_tools.go
@@ -23,6 +23,7 @@ func (*QuotesTool) Tool() mcp.Tool {
 				"type": "string",
 			}),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -69,6 +70,7 @@ func (*InstrumentsSearchTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of instruments to return. If not specified, returns all matching instruments. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -189,6 +191,7 @@ func (*HistoricalDataTool) Tool() mcp.Tool {
 			mcp.Description("Include open interest data"),
 			mcp.DefaultBool(false),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -253,6 +256,7 @@ func (*LTPTool) Tool() mcp.Tool {
 				"type": "string",
 			}),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -295,6 +299,7 @@ func (*OHLCTool) Tool() mcp.Tool {
 				"type": "string",
 			}),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -9,8 +9,6 @@ import (
 	"github.com/zerodha/kite-mcp-server/kc"
 )
 
-// TODO: add destructive, openworld and readonly hints where applicable.
-
 type Tool interface {
 	Tool() gomcp.Tool
 	Handler(*kc.Manager) server.ToolHandlerFunc

--- a/mcp/mf_tools.go
+++ b/mcp/mf_tools.go
@@ -17,6 +17,7 @@ func (*MFHoldingsTool) Tool() mcp.Tool {
 		mcp.WithNumber("limit",
 			mcp.Description("Maximum number of MF holdings to return. If not specified, returns all holdings. When specified, response includes pagination metadata."),
 		),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 

--- a/mcp/post_tools.go
+++ b/mcp/post_tools.go
@@ -77,6 +77,7 @@ func (*PlaceOrderTool) Tool() mcp.Tool {
 			mcp.Description("An optional tag to apply to an order to identify it (alphanumeric, max 20 chars)"),
 			mcp.MaxLength(20),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 
@@ -159,6 +160,7 @@ func (*ModifyOrderTool) Tool() mcp.Tool {
 		mcp.WithNumber("disclosed_quantity",
 			mcp.Description("Quantity to disclose publicly (for equity trades)"),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 
@@ -212,6 +214,7 @@ func (*CancelOrderTool) Tool() mcp.Tool {
 			mcp.Description("Order ID"),
 			mcp.Required(),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 
@@ -304,6 +307,7 @@ func (*PlaceGTTOrderTool) Tool() mcp.Tool {
 		mcp.WithNumber("lower_limit_price",
 			mcp.Description("Limit price for the lower trigger order (for two-leg)"),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 
@@ -377,6 +381,7 @@ func (*DeleteGTTOrderTool) Tool() mcp.Tool {
 			mcp.Description("The ID of the GTT order to delete"),
 			mcp.Required(),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 
@@ -468,6 +473,7 @@ func (*ModifyGTTOrderTool) Tool() mcp.Tool {
 		mcp.WithNumber("lower_limit_price",
 			mcp.Description("Limit price for the lower trigger order (for two-leg)"),
 		),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 }
 

--- a/mcp/setup_tools.go
+++ b/mcp/setup_tools.go
@@ -14,6 +14,7 @@ type LoginTool struct{}
 func (*LoginTool) Tool() mcp.Tool {
 	return mcp.NewTool("login",
 		mcp.WithDescription("Login to Kite API. This tool helps you log in to the Kite API. If you are starting off a new conversation call this tool before hand. Call this if you get a session error. Returns a link that the user should click to authorize access, present as markdown if your client supports so that they can click it easily when rendered."),
+		mcp.WithOpenWorldHintAnnotation(true),
 	)
 }
 


### PR DESCRIPTION
MCP as a protocol allows tools to have [annotations](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations).

These hints are used by MCP clients like [VSCode](https://code.visualstudio.com/api/extension-guides/ai/mcp) and [Qordinate](https://qordinate.ai/) to determine whether to involve human in the loop, and some other decisions like autonomously executing tools.

This PR adds the proper annotations to Kite MCP tools.

<img width="774" height="621" alt="image" src="https://github.com/user-attachments/assets/d67cb9e7-12cd-4800-99e6-72d46450e07e" />
