### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/mcp/get_tools.go
+++ b/mcp/get_tools.go
@@ -13,6 +13,8 @@ type ProfileTool struct{}
 func (*ProfileTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_profile",
 		mcp.WithDescription("Retrieve the user's profile information, including user ID, name, email, and account details like products orders, and exchanges available to the user. Use this to get basic user details."),
+		mcp.WithTitleAnnotation("Get Profile"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -27,6 +29,8 @@ type MarginsTool struct{}
 func (*MarginsTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_margins",
 		mcp.WithDescription("Get margins"),
+		mcp.WithTitleAnnotation("Get Margins"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 
@@ -41,6 +45,8 @@ type HoldingsTool struct{}
 func (*HoldingsTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_holdings",
 		mcp.WithDescription("Get holdings for the current user. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get Holdings"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
@@ -71,6 +77,8 @@ type PositionsTool struct{}
 func (*PositionsTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_positions",
 		mcp.WithDescription("Get current positions. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get Positions"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
@@ -107,6 +115,8 @@ type TradesTool struct{}
 func (*TradesTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_trades",
 		mcp.WithDescription("Get trading history. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get Trades"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
@@ -137,6 +147,8 @@ type OrdersTool struct{}
 func (*OrdersTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_orders",
 		mcp.WithDescription("Get all orders. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get Orders"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
@@ -167,6 +179,8 @@ type GTTOrdersTool struct{}
 func (*GTTOrdersTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_gtts",
 		mcp.WithDescription("Get all active GTT orders. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get GTT Orders"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
@@ -197,6 +211,8 @@ type OrderTradesTool struct{}
 func (*OrderTradesTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_order_trades",
 		mcp.WithDescription("Get trades for a specific order"),
+		mcp.WithTitleAnnotation("Get Order Trades"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("order_id",
 			mcp.Description("ID of the order to fetch trades for"),
 			mcp.Required(),
@@ -233,6 +249,8 @@ type OrderHistoryTool struct{}
 func (*OrderHistoryTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_order_history",
 		mcp.WithDescription("Get order history for a specific order"),
+		mcp.WithTitleAnnotation("Get Order History"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("order_id",
 			mcp.Description("ID of the order to fetch history for"),
 			mcp.Required(),

--- a/mcp/market_tools.go
+++ b/mcp/market_tools.go
@@ -16,6 +16,8 @@ type QuotesTool struct{}
 func (*QuotesTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_quotes",
 		mcp.WithDescription("Get market data quotes for a list of instruments"),
+		mcp.WithTitleAnnotation("Get Quotes"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithArray("instruments",
 			mcp.Description("Eg. ['NSE:INFY', 'NSE:SBIN']. This API returns the complete market data snapshot of up to 500 instruments in one go. It includes the quantity, OHLC, and Open Interest fields, and the complete bid/ask market depth amongst others. Instruments are identified by the exchange:tradingsymbol combination and are passed as values to the query parameter i which is repeated for every instrument. If there is no data available for a given key, the key will be absent from the response."),
 			mcp.Required(),
@@ -55,6 +57,8 @@ type InstrumentsSearchTool struct{}
 func (*InstrumentsSearchTool) Tool() mcp.Tool {
 	return mcp.NewTool("search_instruments", // TODO this can be multiplexed into various modes. Currently only the filter mode is implemented but other instruments queries in the instruments manager can be exposed here as well.
 		mcp.WithDescription("Search instruments. Supports pagination for large result sets."),
+		mcp.WithTitleAnnotation("Search Instruments"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("query",
 			mcp.Description("Search query"),
 			mcp.Required(),
@@ -164,6 +168,8 @@ type HistoricalDataTool struct{}
 func (*HistoricalDataTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_historical_data",
 		mcp.WithDescription("Get historical price data for an instrument"),
+		mcp.WithTitleAnnotation("Get Historical Data"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("instrument_token",
 			mcp.Description("Instrument token (can be obtained from search_instruments tool)"),
 			mcp.Required(),
@@ -246,6 +252,8 @@ type LTPTool struct{}
 func (*LTPTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_ltp",
 		mcp.WithDescription("Get latest trading prices for a list of instruments"),
+		mcp.WithTitleAnnotation("Get LTP"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithArray("instruments",
 			mcp.Description("Eg. ['NSE:INFY', 'NSE:SBIN']. This API returns the lastest price for the given list of instruments in the format of exchange:tradingsymbol."),
 			mcp.Required(),
@@ -288,6 +296,8 @@ type OHLCTool struct{}
 func (*OHLCTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_ohlc",
 		mcp.WithDescription("Get OHLC (Open, High, Low, Close) data for a list of instruments"),
+		mcp.WithTitleAnnotation("Get OHLC"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithArray("instruments",
 			mcp.Description("Eg. ['NSE:INFY', 'NSE:SBIN']. This API returns OHLC data for the given list of instruments in the format of exchange:tradingsymbol."),
 			mcp.Required(),

--- a/mcp/mf_tools.go
+++ b/mcp/mf_tools.go
@@ -11,6 +11,8 @@ type MFHoldingsTool struct{}
 func (*MFHoldingsTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_mf_holdings",
 		mcp.WithDescription("Get all mutual fund holdings. Supports pagination for large datasets."),
+		mcp.WithTitleAnnotation("Get MF Holdings"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),

--- a/mcp/post_tools.go
+++ b/mcp/post_tools.go
@@ -14,6 +14,8 @@ type PlaceOrderTool struct{}
 func (*PlaceOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("place_order",
 		mcp.WithDescription("Place an order"),
+		mcp.WithTitleAnnotation("Place Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("variety",
 			mcp.Description("Order variety"),
 			mcp.Required(),
@@ -126,6 +128,8 @@ type ModifyOrderTool struct{}
 func (*ModifyOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("modify_order",
 		mcp.WithDescription("Modify an existing order"),
+		mcp.WithTitleAnnotation("Modify Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("variety",
 			mcp.Description("Order variety"),
 			mcp.Required(),
@@ -202,6 +206,8 @@ type CancelOrderTool struct{}
 func (*CancelOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("cancel_order",
 		mcp.WithDescription("Cancel an existing order"),
+		mcp.WithTitleAnnotation("Cancel Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("variety",
 			mcp.Description("Order variety"),
 			mcp.Required(),
@@ -246,6 +252,8 @@ type PlaceGTTOrderTool struct{}
 func (*PlaceGTTOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("place_gtt_order",
 		mcp.WithDescription("Place a GTT (Good Till Triggered) order"),
+		mcp.WithTitleAnnotation("Place GTT Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("exchange",
 			mcp.Description("The exchange to which the order should be placed"),
 			mcp.Required(),
@@ -373,6 +381,8 @@ type DeleteGTTOrderTool struct{}
 func (*DeleteGTTOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("delete_gtt_order",
 		mcp.WithDescription("Delete an existing GTT (Good Till Triggered) order"),
+		mcp.WithTitleAnnotation("Delete GTT Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithNumber("trigger_id",
 			mcp.Description("The ID of the GTT order to delete"),
 			mcp.Required(),
@@ -411,6 +421,8 @@ type ModifyGTTOrderTool struct{}
 func (*ModifyGTTOrderTool) Tool() mcp.Tool {
 	return mcp.NewTool("modify_gtt_order",
 		mcp.WithDescription("Modify an existing GTT (Good Till Triggered) order"),
+		mcp.WithTitleAnnotation("Modify GTT Order"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithNumber("trigger_id",
 			mcp.Description("The ID of the GTT order to modify"),
 			mcp.Required(),

--- a/mcp/setup_tools.go
+++ b/mcp/setup_tools.go
@@ -14,6 +14,8 @@ type LoginTool struct{}
 func (*LoginTool) Tool() mcp.Tool {
 	return mcp.NewTool("login",
 		mcp.WithDescription("Login to Kite API. This tool helps you log in to the Kite API. If you are starting off a new conversation call this tool before hand. Call this if you get a session error. Returns a link that the user should click to authorize access, present as markdown if your client supports so that they can click it easily when rendered."),
+		mcp.WithTitleAnnotation("Login"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 }
 


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 22 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to 16 read-only tools (get_*, search_*, login)
- Added `destructiveHint: true` to 6 tools that modify data:
  - `place_order`, `modify_order`, `cancel_order`
  - `place_gtt_order`, `delete_gtt_order`, `modify_gtt_order`
- Added `title` annotations for human-readable display

### Files Modified:
| File | Tools | Category |
|------|-------|----------|
| `mcp/get_tools.go` | 9 | Read-only |
| `mcp/post_tools.go` | 6 | Destructive |
| `mcp/market_tools.go` | 5 | Read-only |
| `mcp/mf_tools.go` | 1 | Read-only |
| `mcp/setup_tools.go` | 1 | Read-only |

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] Server builds successfully (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Annotation values match actual tool behavior:
  - Order placement/modification/cancellation → destructive
  - Data queries and market data → read-only

## Before/After

**Before:**
```go
func (*PlaceOrderTool) Tool() mcp.Tool {
    return mcp.NewTool("place_order",
        mcp.WithDescription("Place an order"),
        mcp.WithString("variety", ...),
    )
}
```

**After:**
```go
func (*PlaceOrderTool) Tool() mcp.Tool {
    return mcp.NewTool("place_order",
        mcp.WithDescription("Place an order"),
        mcp.WithTitleAnnotation("Place Order"),
        mcp.WithDestructiveHintAnnotation(true),
        mcp.WithString("variety", ...),
    )
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)