### PR TITLE
docs: add Cursor MCP setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,30 @@ Then add to your Claude Desktop configuration (`~/.config/Claude/claude_desktop_
 
 For other MCP-compatible clients, use the hosted endpoint `https://mcp.kite.trade/mcp` with [mcp-remote](https://github.com/modelcontextprotocol/mcp-remote) or configure your client to connect directly to the HTTP endpoint.
 
-### Cursor
+### Cursor Setup
+
+The easiest way to get started is using Kite’s hosted MCP server at mcp.kite.trade.
+No local installation, Node.js setup, or API keys are required.
+
+Steps:
+
+1. Open Cursor Settings
+2. Navigate to `Tools & MCP`
+3. Click `New MCP Server`
+4. Add the following to your `mcp.json`
+
+```json
+{
+  "kite": {
+    "type": "http",
+    "url": "https://mcp.kite.trade/mcp"
+  }
+}
+```
+
+5. Save the file
+
+That’s it 🎉
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Then add to your Claude Desktop configuration (`~/.config/Claude/claude_desktop_
 
 For other MCP-compatible clients, use the hosted endpoint `https://mcp.kite.trade/mcp` with [mcp-remote](https://github.com/modelcontextprotocol/mcp-remote) or configure your client to connect directly to the HTTP endpoint.
 
+### Cursor
+
 ## Available Tools
 
 ### Setup & Authentication


### PR DESCRIPTION
This PR adds step-by-step instructions to the README for setting up the Kite MCP server in Cursor.

- It documents how to connect to Kite’s hosted MCP endpoint using Cursor’s Tools & MCP settings.
