### PR TITLE
Add logout tool for multi-account support

### DIFF
--- a/mcp/logout_tools.go
+++ b/mcp/logout_tools.go
@@ -1,0 +1,67 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+type LogoutTool struct{}
+
+func (*LogoutTool) Tool() mcp.Tool {
+	return mcp.NewTool("logout",
+		mcp.WithDescription("Logout from the current Kite session. This invalidates the access token and clears session data, allowing you to log in with a different account. Call this between multi-account operations."),
+	)
+}
+
+func (*LogoutTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler := NewToolHandler(manager)
+		handler.trackToolCall(ctx, "logout")
+
+		mcpClientSession := server.ClientSessionFromContext(ctx)
+		mcpSessionID := mcpClientSession.SessionID()
+		manager.Logger.Info("Logout tool called", "session_id", mcpSessionID)
+
+		// Try to get the current user profile before clearing, for a friendly message
+		var userName string
+		kiteSession, _, err := manager.GetOrCreateSession(mcpSessionID)
+		if err == nil && kiteSession != nil {
+			profile, err := kiteSession.Kite.Client.GetUserProfile()
+			if err == nil {
+				userName = profile.UserName
+			}
+		}
+
+		// Clear session data (invalidates token) but keep MCP session alive for re-login
+		if err := manager.ClearSessionData(mcpSessionID); err != nil {
+			manager.Logger.Error("Failed to clear session data during logout", "session_id", mcpSessionID, "error", err)
+			handler.trackToolError(ctx, "logout", "clear_error")
+			return mcp.NewToolResultError("Failed to logout. Please try again."), nil
+		}
+
+		manager.Logger.Info("COMPLIANCE: User logout completed successfully",
+			"event", "user_logout_success",
+			"session_id", mcpSessionID,
+			"user_name", userName,
+		)
+
+		msg := "Successfully logged out."
+		if userName != "" {
+			msg = fmt.Sprintf("Successfully logged out user %s.", userName)
+		}
+		msg += " You can now log in with a different account using the login tool."
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: msg,
+				},
+			},
+		}, nil
+	}
+}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -21,6 +21,7 @@ func GetAllTools() []Tool {
 	return []Tool{
 		// Tools for setting up the client
 		&LoginTool{},
+		&LogoutTool{},
 
 		// Tools that get data from Kite Connect
 		&ProfileTool{},


### PR DESCRIPTION
## Summary

Adds a `logout` MCP tool that invalidates the current Kite access token and clears session data, enabling users to switch between accounts without restarting the server.

- New `logout` tool in `mcp/logout_tools.go` — calls `ClearSessionData()` to invalidate the token while keeping the MCP session alive for re-login
- Registered in the tool list alongside `login`

## Motivation

Closes #53

Currently there is no way to end a Kite session via MCP. The only options are waiting for the 12-hour auto-expiry or killing the server process. This is a blocker for multi-account workflows where users need to fetch data from several Kite accounts sequentially — each `login` call sees the existing session and returns "already logged in".

## Implementation Details

- Uses the existing `Manager.ClearSessionData()` which already handles token invalidation via `InvalidateAccessToken()` and cleanup hooks
- Follows the same `Tool` interface pattern as `LoginTool` (metrics tracking, session context extraction, compliance logging)
- Fetches the username before clearing for a user-friendly confirmation message
- No new dependencies

## Test plan

- [ ] Call `login` → verify authenticated → call `logout` → verify session cleared
- [ ] Call `logout` → call `login` with different account → verify new session works
- [ ] Call `logout` without an active session → verify graceful handling
- [ ] Verify `InvalidateAccessToken()` is called (token revoked on Kite side)