### PR TITLE
ci: lock down token permissions, attest release binaries, add timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,45 @@ name: CI
 on:
   push:
     branches: [ master, develop ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'justfile'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/**'
   pull_request:
     branches: [ master, develop ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'justfile'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install Nix
-      uses: cachix/install-nix-action@v27
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    
-    - name: Setup Nix environment
-      run: nix develop --command echo "Nix environment ready"
-    
-    - name: Run tests
-      run: nix develop --command just test
-    
-    - name: Run linting
-      run: nix develop --command just lint
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b  # v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Setup Nix environment
+        run: nix develop --command echo "Nix environment ready"
+      - name: Run tests
+        run: nix develop --command just test
+      - name: Run linting
+        run: nix develop --command just lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,55 +9,63 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 45
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install Nix
-      uses: cachix/install-nix-action@v27
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    
-    - name: Setup Nix environment
-      run: nix develop --command echo "Nix environment ready"
-    
-    - name: Run tests
-      run: nix develop --command just test
-    
-    - name: Get version from tag
-      id: version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-    
-    - name: Build for Linux
-      run: nix develop --command bash -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-linux-amd64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
-    
-    - name: Build for macOS (Intel)
-      run: nix develop --command bash -c "GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-darwin-amd64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
-    
-    - name: Build for macOS (Apple Silicon)
-      run: nix develop --command bash -c "GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o kite-mcp-server-darwin-arm64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
-    
-    - name: Build for Windows
-      run: nix develop --command bash -c "GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-windows-amd64.exe -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
-    
-    - name: Make binaries executable
-      run: |
-        chmod +x kite-mcp-server-linux-amd64
-        chmod +x kite-mcp-server-darwin-amd64
-        chmod +x kite-mcp-server-darwin-arm64
-        chmod +x kite-mcp-server-windows-amd64.exe
-    
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          kite-mcp-server-linux-amd64
-          kite-mcp-server-darwin-amd64
-          kite-mcp-server-darwin-arm64
-          kite-mcp-server-windows-amd64.exe
-        generate_release_notes: true
-        draft: false
-        prerelease: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b  # v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Setup Nix environment
+        run: nix develop --command echo "Nix environment ready"
+      - name: Run tests
+        run: nix develop --command just test
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Build for Linux (amd64)
+        run: nix develop --command bash -c "GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-linux-amd64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
+      - name: Attest Linux binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: kite-mcp-server-linux-amd64
+      - name: Build for macOS (Intel amd64)
+        run: nix develop --command bash -c "GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-darwin-amd64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
+      - name: Attest macOS Intel binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: kite-mcp-server-darwin-amd64
+      - name: Build for macOS (Apple Silicon arm64)
+        run: nix develop --command bash -c "GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o kite-mcp-server-darwin-arm64 -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
+      - name: Attest macOS Apple Silicon binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: kite-mcp-server-darwin-arm64
+      - name: Build for Windows (amd64)
+        run: nix develop --command bash -c "GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o kite-mcp-server-windows-amd64.exe -ldflags='-s -w -X main.MCP_SERVER_VERSION=${{ steps.version.outputs.VERSION }}' main.go"
+      - name: Attest Windows binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: kite-mcp-server-windows-amd64.exe
+      - name: Make binaries executable
+        run: |
+          chmod +x kite-mcp-server-linux-amd64
+          chmod +x kite-mcp-server-darwin-amd64
+          chmod +x kite-mcp-server-darwin-arm64
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        with:
+          files: |
+            kite-mcp-server-linux-amd64
+            kite-mcp-server-darwin-amd64
+            kite-mcp-server-darwin-arm64
+            kite-mcp-server-windows-amd64.exe
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

ci.yml:
- `permissions: contents: read` at workflow level. Nothing writes to the repo by default.
- `concurrency` group: new push to the same branch cancels the old run
- `paths` filter: README/LICENSE changes no longer trigger CI
- `timeout-minutes: 20` so a stuck Nix install doesn't eat runner time for hours
- All actions pinned to commit SHA instead of mutable tags

release.yml:
- `actions/attest-build-provenance` after each of the 4 platform builds. Links each binary to this exact commit so users can verify what they downloaded came from this workflow.
- `id-token: write` and `attestations: write` added to permissions (needed for OIDC signing)
- `timeout-minutes: 45`
- All actions pinned to commit SHA

## Why

Anyone downloading a release binary today has no way to check it wasn't swapped after the build. The attestation steps fix that. SHA pinning and a read-only default token were both missing, and OSSF Scorecard flags both.