### PR TITLE
docs: Add MCP configuration for OpenCode - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The server will start and serve a status page at `http://localhost:8080/`
 - [Claude Desktop (HTTP Mode)](#claude-desktop-http-mode) - Recommended
 - [Claude Desktop (SSE Mode)](#claude-desktop-sse-mode)
 - [Claude Desktop (stdio Mode)](#claude-desktop-stdio-mode)
+- [OpenCode](#opencode)
 - [Other MCP Clients](#other-mcp-clients)
 
 ### Claude Desktop (Hosted Mode)
@@ -172,6 +173,25 @@ Then add to your Claude Desktop configuration (`~/.config/Claude/claude_desktop_
 - `/home/username/kite-mcp-server/kite-mcp-server` (Linux)
 - `/Users/username/kite-mcp-server/kite-mcp-server` (macOS)
 - `C:\Users\username\kite-mcp-server\kite-mcp-server.exe` (Windows)
+
+### OpenCode
+
+Add the following to your OpenCode MCP configuration (stored in the global config file; see [OpenCode](https://opencode.ai/docs/config/) for the exact location):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kite": {
+      "command": "npx",
+      "type": "remote",
+      "url": "https://mcp.kite.trade/mcp",
+      "enabled": true
+    }
+  }
+}
+
+```
 
 ### Other MCP Clients
 


### PR DESCRIPTION
# Added MCP configuration for open code

Changes made in the file :
---
### OpenCode

Add the following to your OpenCode MCP configuration (stored in the global config file; see [OpenCode](https://opencode.ai/docs/config/) for the exact location):

```json
{
  "$schema": "https://opencode.ai/config.json",
  "mcp": {
    "kite": {
      "command": "npx",
      "type": "remote",
      "url": "https://mcp.kite.trade/mcp",
      "enabled": true
    }
  }
}

```
---
# Proof of work

<img width="530" height="221" alt="image" src="https://github.com/user-attachments/assets/ff7bae35-8d9a-4778-beee-9c6662bb4c09" />

---