### PR TITLE
feat: add agentic account MVP with budget-capped trading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,13 @@ APP_HOST=localhost   # Host to bind to (use 0.0.0.0 for all interfaces)
 #   - Leave empty to enable all tools
 # EXCLUDED_TOOLS=place_order,modify_order,cancel_order
 
+# Agentic account MVP (optional)
+# ---------------------------
+# AGENTIC_ENABLED: Enable budget-capped agent trading tools
+#   - Adds setup_agent_account, get_agent_account, disconnect_agent
+#   - place_order enforces remaining budget when an agent account is configured
+# AGENTIC_ENABLED=true
+
 # Logging configuration (optional)
 # --------------------------------
 # LOG_LEVEL: Controls verbosity of logs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Model Context Protocol (MCP) server that provides AI assistants with secure ac
 
 Want to use AI with your Kite trading account? Just add `https://mcp.kite.trade/mcp` to your AI client configuration. No installation or API keys required - it's hosted and ready to use.
 
+**Agentic account MVP** (Robinhood-style agent with a trading budget): see [docs/AGENTIC_MVP.md](docs/AGENTIC_MVP.md). Run self-hosted with `AGENTIC_ENABLED=true` and `place_order` enabled.
+
 ## Features
 
 - **Portfolio Management**: View holdings, positions, margins, and mutual fund investments

--- a/agentic/store.go
+++ b/agentic/store.go
@@ -1,0 +1,109 @@
+package agentic
+
+import (
+	"sync"
+	"time"
+)
+
+// Account tracks a per-agent (MCP session) trading budget.
+type Account struct {
+	BudgetINR   float64   `json:"budget_inr"`
+	SpentINR    float64   `json:"spent_inr"`
+	RemainingINR float64  `json:"remaining_inr"`
+	Active      bool      `json:"active"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// Store holds in-memory agentic accounts keyed by MCP session ID.
+type Store struct {
+	mu       sync.RWMutex
+	accounts map[string]*accountState
+}
+
+type accountState struct {
+	budgetINR float64
+	spentINR  float64
+	createdAt time.Time
+}
+
+// NewStore creates an empty agentic account store.
+func NewStore() *Store {
+	return &Store{accounts: make(map[string]*accountState)}
+}
+
+// Setup creates or replaces the budget for a session.
+func (s *Store) Setup(sessionID string, budgetINR float64) Account {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.accounts[sessionID] = &accountState{
+		budgetINR: budgetINR,
+		spentINR:  0,
+		createdAt: time.Now(),
+	}
+	return s.snapshot(sessionID, s.accounts[sessionID])
+}
+
+// Get returns the account for a session, or inactive if none exists.
+func (s *Store) Get(sessionID string) Account {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, ok := s.accounts[sessionID]
+	if !ok {
+		return Account{Active: false}
+	}
+	return s.snapshot(sessionID, state)
+}
+
+// CanSpend reports whether estimated notional fits the remaining budget.
+func (s *Store) CanSpend(sessionID string, estimatedINR float64) (bool, Account, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	state, ok := s.accounts[sessionID]
+	if !ok {
+		return true, Account{Active: false}, ""
+	}
+
+	remaining := state.budgetINR - state.spentINR
+	if estimatedINR > remaining {
+		acct := s.snapshot(sessionID, state)
+		return false, acct, "order exceeds agent budget"
+	}
+	return true, s.snapshot(sessionID, state), ""
+}
+
+// RecordSpend adds to spent after a successful order.
+func (s *Store) RecordSpend(sessionID string, amountINR float64) Account {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.accounts[sessionID]
+	if !ok {
+		return Account{Active: false}
+	}
+	state.spentINR += amountINR
+	return s.snapshot(sessionID, state)
+}
+
+// Remove clears the agentic account for a session.
+func (s *Store) Remove(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.accounts, sessionID)
+}
+
+func (s *Store) snapshot(_ string, state *accountState) Account {
+	remaining := state.budgetINR - state.spentINR
+	if remaining < 0 {
+		remaining = 0
+	}
+	return Account{
+		BudgetINR:    state.budgetINR,
+		SpentINR:     state.spentINR,
+		RemainingINR: remaining,
+		Active:       true,
+		CreatedAt:    state.createdAt,
+	}
+}

--- a/agentic/store_test.go
+++ b/agentic/store_test.go
@@ -1,0 +1,95 @@
+package agentic
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStoreBudgetLifecycle(t *testing.T) {
+	store := NewStore()
+	sessionID := "sess-1"
+
+	acct := store.Setup(sessionID, 10000)
+	if !acct.Active || acct.BudgetINR != 10000 || acct.RemainingINR != 10000 {
+		t.Fatalf("unexpected setup account: %+v", acct)
+	}
+
+	ok, _, reason := store.CanSpend(sessionID, 6000)
+	if !ok || reason != "" {
+		t.Fatalf("expected spend allowed, got ok=%v reason=%q", ok, reason)
+	}
+
+	store.RecordSpend(sessionID, 6000)
+
+	ok, acct, reason = store.CanSpend(sessionID, 5000)
+	if ok || reason == "" {
+		t.Fatalf("expected spend blocked, got ok=%v reason=%q acct=%+v", ok, reason, acct)
+	}
+	if acct.RemainingINR != 4000 {
+		t.Fatalf("expected 4000 remaining, got %v", acct.RemainingINR)
+	}
+
+	store.Remove(sessionID)
+	acct = store.Get(sessionID)
+	if acct.Active {
+		t.Fatal("expected inactive account after remove")
+	}
+}
+
+func TestStoreInactiveSessionAllowsSpend(t *testing.T) {
+	store := NewStore()
+	ok, _, reason := store.CanSpend("unknown", 999999)
+	if !ok || reason != "" {
+		t.Fatalf("inactive session should not block: ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestStoreSetupReplacesExistingBudget(t *testing.T) {
+	store := NewStore()
+	sessionID := "sess-2"
+
+	store.Setup(sessionID, 5000)
+	store.RecordSpend(sessionID, 4000)
+
+	acct := store.Setup(sessionID, 20000)
+	if acct.BudgetINR != 20000 || acct.SpentINR != 0 || acct.RemainingINR != 20000 {
+		t.Fatalf("setup should reset spent: %+v", acct)
+	}
+}
+
+func TestStoreRecordSpendAccumulates(t *testing.T) {
+	store := NewStore()
+	sessionID := "sess-3"
+	store.Setup(sessionID, 1000)
+
+	store.RecordSpend(sessionID, 200)
+	store.RecordSpend(sessionID, 300)
+
+	acct := store.Get(sessionID)
+	if acct.SpentINR != 500 || acct.RemainingINR != 500 {
+		t.Fatalf("unexpected totals: %+v", acct)
+	}
+}
+
+func TestStoreConcurrentAccess(t *testing.T) {
+	store := NewStore()
+	sessionID := "sess-4"
+	store.Setup(sessionID, 100000)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			store.CanSpend(sessionID, 10)
+			store.RecordSpend(sessionID, 1)
+			store.Get(sessionID)
+		}()
+	}
+	wg.Wait()
+
+	acct := store.Get(sessionID)
+	if !acct.Active || acct.SpentINR <= 0 {
+		t.Fatalf("expected active account with spend recorded: %+v", acct)
+	}
+}

--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/mark3labs/mcp-go/util"
+	"github.com/zerodha/kite-mcp-server/agentic"
 	"github.com/zerodha/kite-mcp-server/app/metrics"
 	"github.com/zerodha/kite-mcp-server/kc"
 	"github.com/zerodha/kite-mcp-server/kc/templates"
@@ -45,8 +46,9 @@ type Config struct {
 	AppPort       string
 	AppHost       string
 
-	ExcludedTools   string
-	AdminSecretPath string
+	ExcludedTools    string
+	AdminSecretPath  string
+	AgenticEnabled   bool
 }
 
 // Server mode constants
@@ -74,6 +76,7 @@ func NewApp(logger *slog.Logger) *App {
 
 			ExcludedTools:   os.Getenv("EXCLUDED_TOOLS"),
 			AdminSecretPath: os.Getenv("ADMIN_ENDPOINT_SECRET_PATH"),
+			AgenticEnabled:  os.Getenv("AGENTIC_ENABLED") == "true",
 		},
 		Version:   "v0.0.0", // Ideally injected at build time
 		startTime: time.Now(),
@@ -151,6 +154,11 @@ func (app *App) initializeServices() (*kc.Manager, *server.MCPServer, error) {
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Kite Connect manager: %w", err)
+	}
+
+	if app.Config.AgenticEnabled {
+		kcManager.Agentic = agentic.NewStore()
+		app.logger.Info("Agentic account mode enabled")
 	}
 
 	// Store reference for template data

--- a/docs/AGENTIC_MVP.md
+++ b/docs/AGENTIC_MVP.md
@@ -1,0 +1,113 @@
+# Agentic Account MVP (Kite)
+
+Robinhood-style “agentic account” flow on top of this MCP server: connect an AI agent, cap how much it can trade, and disconnect when done.
+
+## What you already have
+
+| Robinhood step | This repo |
+|----------------|-----------|
+| Connect via MCP | `http://localhost:8080/mcp` (or hosted `https://mcp.kite.trade/mcp`) |
+| Login / authorize | `login` tool → Kite OAuth in browser |
+| Agent places trades | `place_order`, `get_quotes`, `search_instruments`, etc. |
+| Disconnect | `disconnect_agent` (MVP) |
+
+## What the MVP adds
+
+With `AGENTIC_ENABLED=true`:
+
+- **`setup_agent_account`** — set a dedicated INR budget for this agent session
+- **`get_agent_account`** — budget, spent, remaining
+- **`disconnect_agent`** — clear budget + log out Kite for this session
+- **`place_order`** — blocked if estimated order value exceeds remaining budget
+
+## Quick start
+
+### 1. Configure
+
+```env
+KITE_API_KEY=your_key
+KITE_API_SECRET=your_secret
+APP_MODE=http
+APP_PORT=8080
+AGENTIC_ENABLED=true
+# Do NOT exclude place_order — agent needs it
+EXCLUDED_TOOLS=
+```
+
+### 2. Run
+
+```bash
+go run main.go
+```
+
+### 3. Connect Cursor (or Claude)
+
+Add to Cursor MCP settings (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "kite-agent": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:8080/mcp", "--allow-http"]
+    }
+  }
+}
+```
+
+### 4. Agent flow (example prompt)
+
+Ask your agent:
+
+1. **Login** — call `login`, open the link, complete Kite auth  
+2. **Fund the agentic account** — `setup_agent_account` with `budget_inr: 50000` (or whatever cap you want)  
+3. **Research** — `search_instruments`, `get_quotes`  
+4. **Trade** — `place_order` (MARKET/LIMIT as needed); over-budget orders are rejected  
+5. **Monitor** — `get_agent_account`, `get_orders`, `get_holdings`  
+6. **Stop** — `disconnect_agent` when finished  
+
+Example trade (agent must fill real symbol/params):
+
+```text
+Place a market BUY for 1 share of RELIANCE on NSE, product CNC, after confirming quote and budget.
+```
+
+### 5. Safety notes
+
+- Budget is **per MCP session** (in-memory; resets on server restart).
+- Estimates use LTP for market orders; actual fill may differ slightly.
+- This is **real money** on your Kite account — start with a small `budget_inr`.
+- Hosted `mcp.kite.trade` excludes `place_order`; run **self-hosted** for agentic trading.
+
+## Tool reference
+
+| Tool | Purpose |
+|------|---------|
+| `login` | Kite OAuth |
+| `setup_agent_account` | Set `budget_inr` cap |
+| `get_agent_account` | Budget status |
+| `place_order` | Execute trade (budget-guarded when agentic enabled) |
+| `disconnect_agent` | Revoke agent access for this session |
+
+## Tests
+
+Unit tests cover budget math, order blocking, MCP tool handlers, and session cleanup:
+
+```bash
+go test ./agentic/... ./mcp/... ./kc/... -run 'Agentic|Estimate|CheckAgentic|SetupAgent|GetAgent|Disconnect|Store|Cleanup'
+```
+
+What tests **do not** cover (requires your Kite credentials + manual run):
+
+- Full OAuth `login` flow in a browser
+- Live `place_order` execution on the exchange
+- Hosted `mcp.kite.trade` (trading tools excluded there)
+
+## Out of scope (full product)
+
+- Separate brokerage sub-account
+- Push notifications per trade
+- Mobile dashboard UI
+- Paper trading sandbox
+
+These can be layered later; the MVP proves **MCP + budget + trade + disconnect** end-to-end.

--- a/kc/manager.go
+++ b/kc/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	kiteconnect "github.com/zerodha/gokiteconnect/v4"
+	"github.com/zerodha/kite-mcp-server/agentic"
 	"github.com/zerodha/kite-mcp-server/app/metrics"
 	"github.com/zerodha/kite-mcp-server/kc/instruments"
 	"github.com/zerodha/kite-mcp-server/kc/templates"
@@ -121,6 +122,7 @@ type Manager struct {
 	Instruments    *instruments.Manager
 	sessionManager *SessionRegistry
 	sessionSigner  *SessionSigner
+	Agentic        *agentic.Store
 }
 
 // NewManager creates a new manager with default configuration
@@ -174,6 +176,9 @@ func (m *Manager) initializeSessionManager() {
 
 // kiteSessionCleanupHook handles cleanup of Kite sessions
 func (m *Manager) kiteSessionCleanupHook(session *MCPSession) {
+	if m.Agentic != nil {
+		m.Agentic.Remove(session.ID)
+	}
 	if kiteData, ok := session.Data.(*KiteSessionData); ok && kiteData != nil && kiteData.Kite != nil {
 		m.Logger.Info("Cleaning up Kite session for MCP session ID", "session_id", session.ID)
 		_, _ = kiteData.Kite.Client.InvalidateAccessToken()

--- a/kc/manager_agentic_test.go
+++ b/kc/manager_agentic_test.go
@@ -1,0 +1,40 @@
+package kc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zerodha/kite-mcp-server/agentic"
+)
+
+func TestKiteSessionCleanupHookClearsAgenticAccount(t *testing.T) {
+	manager, err := newTestManager("test_key", "test_secret")
+	require.NoError(t, err)
+
+	manager.Agentic = agentic.NewStore()
+	sessionID := manager.sessionManager.GenerateWithData(&KiteSessionData{Kite: NewKiteConnect("test_key")})
+	manager.Agentic.Setup(sessionID, 7500)
+
+	session, err := manager.sessionManager.GetSession(sessionID)
+	require.NoError(t, err)
+
+	manager.kiteSessionCleanupHook(session)
+
+	acct := manager.Agentic.Get(sessionID)
+	assert.False(t, acct.Active)
+}
+
+func TestClearSessionDataClearsAgenticBudget(t *testing.T) {
+	manager, err := newTestManager("test_key", "test_secret")
+	require.NoError(t, err)
+
+	manager.Agentic = agentic.NewStore()
+	sessionID := manager.sessionManager.GenerateWithData(&KiteSessionData{Kite: NewKiteConnect("test_key")})
+	manager.Agentic.Setup(sessionID, 3000)
+
+	require.NoError(t, manager.ClearSessionData(sessionID))
+
+	acct := manager.Agentic.Get(sessionID)
+	assert.False(t, acct.Active)
+}

--- a/mcp/agentic_guard.go
+++ b/mcp/agentic_guard.go
@@ -1,0 +1,50 @@
+package mcp
+
+import (
+	"fmt"
+
+	gomcp "github.com/mark3labs/mcp-go/mcp"
+	kiteconnect "github.com/zerodha/gokiteconnect/v4"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+// estimateOrderNotionalINR estimates order value in INR for budget checks.
+func estimateOrderNotionalINR(client *kiteconnect.Client, exchange, tradingsymbol, orderType string, quantity int, price float64) (float64, error) {
+	unitPrice := price
+
+	if orderType == "MARKET" || orderType == "SL-M" || unitPrice <= 0 {
+		instrument := fmt.Sprintf("%s:%s", exchange, tradingsymbol)
+		ltp, err := client.GetLTP(instrument)
+		if err != nil {
+			return 0, fmt.Errorf("failed to fetch LTP for budget check: %w", err)
+		}
+		quote, ok := ltp[instrument]
+		if !ok || quote.LastPrice <= 0 {
+			return 0, fmt.Errorf("no LTP available for %s", instrument)
+		}
+		unitPrice = quote.LastPrice
+	}
+
+	return unitPrice * float64(quantity), nil
+}
+
+func checkAgenticBudget(manager *kc.Manager, sessionID string, session *kc.KiteSessionData, exchange, tradingsymbol, orderType string, quantity int, price float64) (*gomcp.CallToolResult, float64, bool) {
+	if manager.Agentic == nil {
+		return nil, 0, true
+	}
+
+	estimated, err := estimateOrderNotionalINR(session.Kite.Client, exchange, tradingsymbol, orderType, quantity, price)
+	if err != nil {
+		return gomcp.NewToolResultError(err.Error()), 0, false
+	}
+
+	ok, account, reason := manager.Agentic.CanSpend(sessionID, estimated)
+	if !ok {
+		return gomcp.NewToolResultText(fmt.Sprintf(
+			"Order blocked: %s. Agent budget: ₹%.2f, spent: ₹%.2f, remaining: ₹%.2f, estimated order: ₹%.2f. Use get_agent_account for details or disconnect_agent to revoke access.",
+			reason, account.BudgetINR, account.SpentINR, account.RemainingINR, estimated,
+		)), estimated, false
+	}
+
+	return nil, estimated, true
+}

--- a/mcp/agentic_guard_test.go
+++ b/mcp/agentic_guard_test.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gomcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kiteconnect "github.com/zerodha/gokiteconnect/v4"
+	"github.com/zerodha/kite-mcp-server/agentic"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+func newTestKiteClientWithLTP(t *testing.T, instrument string, lastPrice float64) *kiteconnect.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/quote" {
+			http.NotFound(w, r)
+			return
+		}
+		payload := map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				instrument: map[string]any{
+					"instrument_token": 1,
+					"last_price":       lastPrice,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := kiteconnect.New("test_api_key")
+	client.SetBaseURI(srv.URL)
+	return client
+}
+
+func newAgenticTestManager(t *testing.T, withBudget bool, budgetINR float64, sessionID string) (*kc.Manager, *kc.KiteSessionData) {
+	t.Helper()
+
+	manager, err := kc.New(kc.Config{
+		APIKey:    "test_key",
+		APISecret: "test_secret",
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+
+	manager.Agentic = agentic.NewStore()
+	if withBudget {
+		manager.Agentic.Setup(sessionID, budgetINR)
+	}
+
+	session := &kc.KiteSessionData{
+		Kite: &kc.KiteConnect{Client: kiteconnect.New("test_api_key")},
+	}
+	return manager, session
+}
+
+func TestEstimateOrderNotionalINR_LimitOrderUsesPrice(t *testing.T) {
+	client := kiteconnect.New("test_key")
+
+	notional, err := estimateOrderNotionalINR(client, "NSE", "RELIANCE", "LIMIT", 2, 2500.50)
+	require.NoError(t, err)
+	assert.InDelta(t, 5001.0, notional, 0.01)
+}
+
+func TestEstimateOrderNotionalINR_MarketOrderUsesLTP(t *testing.T) {
+	client := newTestKiteClientWithLTP(t, "NSE:RELIANCE", 1234.5)
+
+	notional, err := estimateOrderNotionalINR(client, "NSE", "RELIANCE", "MARKET", 3, 0)
+	require.NoError(t, err)
+	assert.InDelta(t, 3703.5, notional, 0.01)
+}
+
+func TestCheckAgenticBudget_DisabledStoreAllowsAll(t *testing.T) {
+	manager, session := newAgenticTestManager(t, false, 0, "sess-a")
+	manager.Agentic = nil
+
+	result, estimated, ok := checkAgenticBudget(manager, "sess-a", session, "NSE", "RELIANCE", "LIMIT", 1, 100)
+	assert.Nil(t, result)
+	assert.Equal(t, 0.0, estimated)
+	assert.True(t, ok)
+}
+
+func TestCheckAgenticBudget_NoAccountConfiguredAllowsOrder(t *testing.T) {
+	manager, session := newAgenticTestManager(t, false, 0, "sess-b")
+
+	result, estimated, ok := checkAgenticBudget(manager, "sess-b", session, "NSE", "RELIANCE", "LIMIT", 1, 100)
+	assert.Nil(t, result)
+	assert.InDelta(t, 100.0, estimated, 0.01)
+	assert.True(t, ok)
+}
+
+func TestCheckAgenticBudget_WithinBudget(t *testing.T) {
+	const sessionID = "sess-c"
+	manager, session := newAgenticTestManager(t, true, 10000, sessionID)
+
+	result, estimated, ok := checkAgenticBudget(manager, sessionID, session, "NSE", "RELIANCE", "LIMIT", 2, 1000)
+	assert.Nil(t, result)
+	assert.InDelta(t, 2000.0, estimated, 0.01)
+	assert.True(t, ok)
+}
+
+func TestCheckAgenticBudget_ExceedsBudget(t *testing.T) {
+	const sessionID = "sess-d"
+	manager, session := newAgenticTestManager(t, true, 1000, sessionID)
+
+	result, estimated, ok := checkAgenticBudget(manager, sessionID, session, "NSE", "RELIANCE", "LIMIT", 5, 500)
+	require.NotNil(t, result)
+	assert.False(t, ok)
+	assert.InDelta(t, 2500.0, estimated, 0.01)
+	text, ok := gomcp.AsTextContent(result.Content[0])
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "Order blocked")
+}
+
+func TestCheckAgenticBudget_MarketOrderBlockedWhenOverBudget(t *testing.T) {
+	const sessionID = "sess-e"
+	manager, session := newAgenticTestManager(t, true, 500, sessionID)
+	session.Kite.Client = newTestKiteClientWithLTP(t, "NSE:RELIANCE", 1000)
+
+	result, _, ok := checkAgenticBudget(manager, sessionID, session, "NSE", "RELIANCE", "MARKET", 1, 0)
+	require.NotNil(t, result)
+	assert.False(t, ok)
+}

--- a/mcp/agentic_tools.go
+++ b/mcp/agentic_tools.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	gomcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+type SetupAgentAccountTool struct{}
+
+func (*SetupAgentAccountTool) Tool() gomcp.Tool {
+	return gomcp.NewTool("setup_agent_account",
+		gomcp.WithDescription("Create an agentic trading account for this agent session with a dedicated INR budget. Call after login and before placing orders. Orders via place_order are blocked when they exceed the remaining budget."),
+		gomcp.WithNumber("budget_inr",
+			gomcp.Description("Maximum INR the agent may deploy via place_order in this session"),
+			gomcp.Required(),
+			gomcp.Min(1),
+		),
+	)
+}
+
+func (*SetupAgentAccountTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "setup_agent_account")
+		args := request.GetArguments()
+
+		if err := ValidateRequired(args, "budget_inr"); err != nil {
+			return gomcp.NewToolResultError(err.Error()), nil
+		}
+
+		if manager.Agentic == nil {
+			return gomcp.NewToolResultError("Agentic accounts are not enabled on this server"), nil
+		}
+
+		budget := SafeAssertFloat64(args["budget_inr"], 0)
+		if budget <= 0 {
+			return gomcp.NewToolResultError("budget_inr must be greater than 0"), nil
+		}
+
+		sess := server.ClientSessionFromContext(ctx)
+		account := manager.Agentic.Setup(sess.SessionID(), budget)
+
+		return handler.MarshalResponse(map[string]any{
+			"message": fmt.Sprintf("Agentic account ready with ₹%.2f budget. Trades are capped to this amount for this agent session.", budget),
+			"account": account,
+		}, "setup_agent_account")
+	}
+}
+
+type GetAgentAccountTool struct{}
+
+func (*GetAgentAccountTool) Tool() gomcp.Tool {
+	return gomcp.NewTool("get_agent_account",
+		gomcp.WithDescription("Get the agentic account status: budget, spent, and remaining INR for this agent session."),
+	)
+}
+
+func (*GetAgentAccountTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "get_agent_account")
+
+		if manager.Agentic == nil {
+			return gomcp.NewToolResultError("Agentic accounts are not enabled on this server"), nil
+		}
+
+		sess := server.ClientSessionFromContext(ctx)
+		account := manager.Agentic.Get(sess.SessionID())
+
+		return handler.MarshalResponse(account, "get_agent_account")
+	}
+}
+
+type DisconnectAgentTool struct{}
+
+func (*DisconnectAgentTool) Tool() gomcp.Tool {
+	return gomcp.NewTool("disconnect_agent",
+		gomcp.WithDescription("Disconnect the agent: clears the agentic budget and logs out the linked Kite session. The agent cannot trade until the user logs in again via the login tool."),
+	)
+}
+
+func (*DisconnectAgentTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "disconnect_agent")
+
+		sess := server.ClientSessionFromContext(ctx)
+		sessionID := sess.SessionID()
+
+		if manager.Agentic != nil {
+			manager.Agentic.Remove(sessionID)
+		}
+
+		if err := manager.ClearSessionData(sessionID); err != nil {
+			handler.manager.Logger.Warn("disconnect_agent: session data clear", "session_id", sessionID, "error", err)
+		}
+
+		return handler.MarshalResponse(map[string]string{
+			"status":  "disconnected",
+			"message": "Agent disconnected. Kite login and agentic budget cleared for this session.",
+		}, "disconnect_agent")
+	}
+}

--- a/mcp/agentic_tools_test.go
+++ b/mcp/agentic_tools_test.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	gomcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zerodha/kite-mcp-server/agentic"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+type fakeMCPClientSession struct {
+	id string
+	ch chan gomcp.JSONRPCNotification
+}
+
+func (f fakeMCPClientSession) SessionID() string { return f.id }
+func (f fakeMCPClientSession) Initialize()       {}
+func (f fakeMCPClientSession) Initialized() bool { return true }
+func (f fakeMCPClientSession) NotificationChannel() chan<- gomcp.JSONRPCNotification {
+	if f.ch == nil {
+		f.ch = make(chan gomcp.JSONRPCNotification)
+	}
+	return f.ch
+}
+
+func toolContext(t *testing.T, sessionID string) context.Context {
+	t.Helper()
+	srv := server.NewMCPServer("test", "v0")
+	return srv.WithContext(context.Background(), fakeMCPClientSession{id: sessionID})
+}
+
+func callToolRequest(args map[string]any) gomcp.CallToolRequest {
+	return gomcp.CallToolRequest{
+		Params: gomcp.CallToolParams{
+			Arguments: args,
+		},
+	}
+}
+
+func toolResultText(t *testing.T, result *gomcp.CallToolResult) string {
+	t.Helper()
+	require.NotEmpty(t, result.Content)
+	text, ok := gomcp.AsTextContent(result.Content[0])
+	require.True(t, ok)
+	return text.Text
+}
+
+func newAgenticToolsTestManager(t *testing.T) *kc.Manager {
+	t.Helper()
+	manager, err := kc.New(kc.Config{
+		APIKey:    "test_key",
+		APISecret: "test_secret",
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	manager.Agentic = agentic.NewStore()
+	return manager
+}
+
+func TestAgenticToolsRegistered(t *testing.T) {
+	names := make(map[string]bool)
+	for _, tool := range GetAllTools() {
+		names[tool.Tool().Name] = true
+	}
+	assert.True(t, names["setup_agent_account"])
+	assert.True(t, names["get_agent_account"])
+	assert.True(t, names["disconnect_agent"])
+}
+
+func TestSetupAgentAccountTool_Success(t *testing.T) {
+	const sessionID = "kitemcp-00000000-0000-4000-8000-000000000001"
+	manager := newAgenticToolsTestManager(t)
+	ctx := toolContext(t, sessionID)
+
+	result, err := (&SetupAgentAccountTool{}).Handler(manager)(ctx, callToolRequest(map[string]any{
+		"budget_inr": 25000.0,
+	}))
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	body := toolResultText(t, result)
+	assert.Contains(t, body, "25000")
+	assert.Contains(t, body, "Agentic account ready")
+
+	acct := manager.Agentic.Get(sessionID)
+	assert.True(t, acct.Active)
+	assert.Equal(t, 25000.0, acct.BudgetINR)
+}
+
+func TestSetupAgentAccountTool_RequiresAgenticEnabled(t *testing.T) {
+	manager := newAgenticToolsTestManager(t)
+	manager.Agentic = nil
+	ctx := toolContext(t, "kitemcp-00000000-0000-4000-8000-000000000002")
+
+	result, err := (&SetupAgentAccountTool{}).Handler(manager)(ctx, callToolRequest(map[string]any{
+		"budget_inr": 1000.0,
+	}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, toolResultText(t, result), "not enabled")
+}
+
+func TestSetupAgentAccountTool_RequiresBudget(t *testing.T) {
+	manager := newAgenticToolsTestManager(t)
+	ctx := toolContext(t, "kitemcp-00000000-0000-4000-8000-000000000003")
+
+	result, err := (&SetupAgentAccountTool{}).Handler(manager)(ctx, callToolRequest(map[string]any{}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestGetAgentAccountTool_ActiveAccount(t *testing.T) {
+	const sessionID = "kitemcp-00000000-0000-4000-8000-000000000004"
+	manager := newAgenticToolsTestManager(t)
+	manager.Agentic.Setup(sessionID, 8000)
+	manager.Agentic.RecordSpend(sessionID, 1500)
+	ctx := toolContext(t, sessionID)
+
+	result, err := (&GetAgentAccountTool{}).Handler(manager)(ctx, callToolRequest(nil))
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var acct agentic.Account
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(t, result)), &acct))
+	assert.True(t, acct.Active)
+	assert.Equal(t, 8000.0, acct.BudgetINR)
+	assert.Equal(t, 1500.0, acct.SpentINR)
+	assert.Equal(t, 6500.0, acct.RemainingINR)
+}
+
+func TestDisconnectAgentTool_ClearsBudget(t *testing.T) {
+	const sessionID = "kitemcp-00000000-0000-4000-8000-000000000005"
+	manager := newAgenticToolsTestManager(t)
+	manager.Agentic.Setup(sessionID, 5000)
+	ctx := toolContext(t, sessionID)
+
+	result, err := (&DisconnectAgentTool{}).Handler(manager)(ctx, callToolRequest(nil))
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, toolResultText(t, result), "disconnected")
+	assert.False(t, manager.Agentic.Get(sessionID).Active)
+}

--- a/mcp/common_test.go
+++ b/mcp/common_test.go
@@ -217,7 +217,7 @@ func TestToolExclusion(t *testing.T) {
 		}
 
 		// Verify essential tools exist
-		essential := []string{"login", "get_profile", "place_order", "get_quotes"}
+		essential := []string{"login", "get_profile", "place_order", "get_quotes", "setup_agent_account", "get_agent_account", "disconnect_agent"}
 		for _, toolName := range essential {
 			assert.True(t, toolNames[toolName], "Essential tool missing: %s", toolName)
 		}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -22,6 +22,11 @@ func GetAllTools() []Tool {
 		// Tools for setting up the client
 		&LoginTool{},
 
+		// Agentic account (optional budget + disconnect)
+		&SetupAgentAccountTool{},
+		&GetAgentAccountTool{},
+		&DisconnectAgentTool{},
+
 		// Tools that get data from Kite Connect
 		&ProfileTool{},
 		&MarginsTool{},

--- a/mcp/post_tools.go
+++ b/mcp/post_tools.go
@@ -110,10 +110,33 @@ func (*PlaceOrderTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 		}
 
 		return handler.WithSession(ctx, "place_order", func(session *kc.KiteSessionData) (*mcp.CallToolResult, error) {
+			sess := server.ClientSessionFromContext(ctx)
+			sessionID := sess.SessionID()
+
+			var estimated float64
+			if blocked, est, ok := checkAgenticBudget(
+				handler.manager,
+				sessionID,
+				session,
+				orderParams.Exchange,
+				orderParams.Tradingsymbol,
+				orderParams.OrderType,
+				orderParams.Quantity,
+				orderParams.Price,
+			); !ok {
+				return blocked, nil
+			} else {
+				estimated = est
+			}
+
 			resp, err := session.Kite.Client.PlaceOrder(variety, orderParams)
 			if err != nil {
 				handler.manager.Logger.Error("Failed to place order", "error", err)
 				return mcp.NewToolResultError("Failed to place order"), nil
+			}
+
+			if handler.manager.Agentic != nil && estimated > 0 {
+				handler.manager.Agentic.RecordSpend(sessionID, estimated)
 			}
 
 			return handler.MarshalResponse(resp, "place_order")


### PR DESCRIPTION
## Summary

Adds an optional **agentic account MVP** so AI agents can trade via MCP with a per-session INR budget (connect → budget cap → trade → disconnect). Inspired by [Robinhood's Agentic Trading](https://robinhood.com/us/en/agentic-trading/)

- New `agentic` package and `AGENTIC_ENABLED=true` server flag
- MCP tools: `setup_agent_account`, `get_agent_account`, `disconnect_agent`
- `place_order` enforces remaining budget using estimated notional (LIMIT uses price; MARKET uses LTP)
- Agentic state cleared on session cleanup / disconnect
- Setup guide: `docs/AGENTIC_MVP.md`

Opt-in only, existing behavior is unchanged when agentic mode is off or no agent account is configured. 