### PR TITLE
Add Kite alert MCP tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.31.0
-	github.com/zerodha/gokiteconnect/v4 v4.3.5
+	github.com/zerodha/gokiteconnect/v4 v4.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/zerodha/gokiteconnect/v4 v4.3.5 h1:NIhcaNXeH/a6j3FBxPIwjh0Tx1ti4z2GODWdBoOHMFc=
 github.com/zerodha/gokiteconnect/v4 v4.3.5/go.mod h1:ym/xXldKyPzkpN7JZpg6Cbjs+nGfqvMC5X9BsHEil9s=
+github.com/zerodha/gokiteconnect/v4 v4.4.0 h1:LHuv7nUe520se6EEnRZLHMjOih4fo9OhnJnODN+ek2M=
+github.com/zerodha/gokiteconnect/v4 v4.4.0/go.mod h1:JsOFotex2pCS53EpYJADRpN5Xp4f5+jgAQsIjEWGFrw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20180719183105-8007e27cdb32 h1:30DLrQoRqdUHslVMzxuKUnY4GKJGk1/FJtKy3yx4TKE=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20180719183105-8007e27cdb32/go.mod h1:d3R+NllX3X5e0zlG1Rful3uLvsGC/Q3OHut5464DEQw=

--- a/mcp/alerts_tools.go
+++ b/mcp/alerts_tools.go
@@ -1,0 +1,305 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	kiteconnect "github.com/zerodha/gokiteconnect/v4"
+	"github.com/zerodha/kite-mcp-server/kc"
+)
+
+const (
+	alertTypeSimple     = "simple"
+	alertTypeATO        = "ato"
+	alertRHSConstant    = "constant"
+	alertRHSInstrument  = "instrument"
+	alertBasketRequired = "basket is required for ato alerts"
+)
+
+func alertToolFields() []mcp.ToolOption {
+	return []mcp.ToolOption{
+		mcp.WithString("name",
+			mcp.Description("Name of the alert"),
+			mcp.Required(),
+		),
+		mcp.WithString("type",
+			mcp.Description("Alert type"),
+			mcp.Required(),
+			mcp.Enum(alertTypeSimple, alertTypeATO),
+		),
+		mcp.WithString("lhs_exchange",
+			mcp.Description("Exchange for the left-hand side instrument"),
+			mcp.Required(),
+			mcp.Enum("NSE", "BSE", "NFO", "CDS", "BCD", "MCX", "INDICES"),
+		),
+		mcp.WithString("lhs_tradingsymbol",
+			mcp.Description("Trading symbol for the left-hand side instrument"),
+			mcp.Required(),
+		),
+		mcp.WithString("lhs_attribute",
+			mcp.Description("Attribute to monitor, for example LastTradedPrice"),
+			mcp.Required(),
+		),
+		mcp.WithString("operator",
+			mcp.Description("Comparison operator"),
+			mcp.Required(),
+			mcp.Enum("<=", ">=", "<", ">", "=="),
+		),
+		mcp.WithString("rhs_type",
+			mcp.Description("Right-hand side comparison type"),
+			mcp.Required(),
+			mcp.Enum(alertRHSConstant, alertRHSInstrument),
+		),
+		mcp.WithNumber("rhs_constant",
+			mcp.Description("Constant value to compare against when rhs_type is constant"),
+		),
+		mcp.WithString("rhs_exchange",
+			mcp.Description("Exchange for the right-hand side instrument when rhs_type is instrument"),
+			mcp.Enum("NSE", "BSE", "NFO", "CDS", "BCD", "MCX", "INDICES"),
+		),
+		mcp.WithString("rhs_tradingsymbol",
+			mcp.Description("Trading symbol for the right-hand side instrument when rhs_type is instrument"),
+		),
+		mcp.WithString("rhs_attribute",
+			mcp.Description("Attribute for the right-hand side instrument when rhs_type is instrument"),
+		),
+		mcp.WithString("basket",
+			mcp.Description("JSON basket payload required for ato alerts"),
+		),
+	}
+}
+
+func buildAlertParams(args map[string]interface{}) (kiteconnect.AlertParams, error) {
+	if err := ValidateRequired(args, "name", "type", "lhs_exchange", "lhs_tradingsymbol", "lhs_attribute", "operator", "rhs_type"); err != nil {
+		return kiteconnect.AlertParams{}, err
+	}
+
+	params := kiteconnect.AlertParams{
+		Name:             SafeAssertString(args["name"], ""),
+		Type:             kiteconnect.AlertType(SafeAssertString(args["type"], alertTypeSimple)),
+		LHSExchange:      SafeAssertString(args["lhs_exchange"], ""),
+		LHSTradingSymbol: SafeAssertString(args["lhs_tradingsymbol"], ""),
+		LHSAttribute:     SafeAssertString(args["lhs_attribute"], ""),
+		Operator:         kiteconnect.AlertOperator(SafeAssertString(args["operator"], "")),
+		RHSType:          SafeAssertString(args["rhs_type"], ""),
+	}
+
+	switch params.RHSType {
+	case alertRHSConstant:
+		if err := ValidateRequired(args, "rhs_constant"); err != nil {
+			return kiteconnect.AlertParams{}, err
+		}
+		params.RHSConstant = SafeAssertFloat64(args["rhs_constant"], 0)
+	case alertRHSInstrument:
+		if err := ValidateRequired(args, "rhs_exchange", "rhs_tradingsymbol", "rhs_attribute"); err != nil {
+			return kiteconnect.AlertParams{}, err
+		}
+		params.RHSExchange = SafeAssertString(args["rhs_exchange"], "")
+		params.RHSTradingSymbol = SafeAssertString(args["rhs_tradingsymbol"], "")
+		params.RHSAttribute = SafeAssertString(args["rhs_attribute"], "")
+	default:
+		return kiteconnect.AlertParams{}, ValidationError{Parameter: "rhs_type", Message: "must be constant or instrument"}
+	}
+
+	if params.Type == alertTypeATO {
+		basketJSON := SafeAssertString(args["basket"], "")
+		if basketJSON == "" {
+			return kiteconnect.AlertParams{}, ValidationError{Parameter: "basket", Message: alertBasketRequired}
+		}
+		var basket kiteconnect.Basket
+		if err := json.Unmarshal([]byte(basketJSON), &basket); err != nil {
+			return kiteconnect.AlertParams{}, ValidationError{Parameter: "basket", Message: "must be valid JSON"}
+		}
+		params.Basket = &basket
+	}
+
+	return params, nil
+}
+
+type GetAlertsTool struct{}
+
+func (*GetAlertsTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_alerts",
+		mcp.WithDescription("Get Kite alerts, optionally filtered by status and paginated by Kite"),
+		mcp.WithString("status",
+			mcp.Description("Filter alerts by status"),
+			mcp.Enum("enabled", "disabled", "deleted"),
+		),
+		mcp.WithNumber("page",
+			mcp.Description("Kite alerts page number"),
+		),
+		mcp.WithNumber("page_size",
+			mcp.Description("Number of alerts per page"),
+		),
+	)
+}
+
+func (*GetAlertsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "get_alerts")
+		args := request.GetArguments()
+		filters := map[string]string{}
+		for _, key := range []string{"status", "page", "page_size"} {
+			if value := SafeAssertString(args[key], ""); value != "" {
+				filters[key] = value
+			}
+		}
+
+		return handler.HandleAPICall(ctx, "get_alerts", func(session *kc.KiteSessionData) (interface{}, error) {
+			return session.Kite.Client.GetAlerts(filters)
+		})
+	}
+}
+
+type GetAlertTool struct{}
+
+func (*GetAlertTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_alert",
+		mcp.WithDescription("Get a Kite alert by UUID"),
+		mcp.WithString("uuid",
+			mcp.Description("Alert UUID"),
+			mcp.Required(),
+		),
+	)
+}
+
+func (*GetAlertTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "get_alert")
+		args := request.GetArguments()
+		if err := ValidateRequired(args, "uuid"); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		uuid := SafeAssertString(args["uuid"], "")
+		return handler.HandleAPICall(ctx, "get_alert", func(session *kc.KiteSessionData) (interface{}, error) {
+			return session.Kite.Client.GetAlert(uuid)
+		})
+	}
+}
+
+type GetAlertHistoryTool struct{}
+
+func (*GetAlertHistoryTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_alert_history",
+		mcp.WithDescription("Get trigger history for a Kite alert by UUID"),
+		mcp.WithString("uuid",
+			mcp.Description("Alert UUID"),
+			mcp.Required(),
+		),
+	)
+}
+
+func (*GetAlertHistoryTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "get_alert_history")
+		args := request.GetArguments()
+		if err := ValidateRequired(args, "uuid"); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		uuid := SafeAssertString(args["uuid"], "")
+		return handler.HandleAPICall(ctx, "get_alert_history", func(session *kc.KiteSessionData) (interface{}, error) {
+			return session.Kite.Client.GetAlertHistory(uuid)
+		})
+	}
+}
+
+type CreateAlertTool struct{}
+
+func (*CreateAlertTool) Tool() mcp.Tool {
+	options := append([]mcp.ToolOption{mcp.WithDescription("Create a Kite alert")}, alertToolFields()...)
+	return mcp.NewTool("create_alert", options...)
+}
+
+func (*CreateAlertTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "create_alert")
+		params, err := buildAlertParams(request.GetArguments())
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return handler.HandleAPICall(ctx, "create_alert", func(session *kc.KiteSessionData) (interface{}, error) {
+			return session.Kite.Client.CreateAlert(params)
+		})
+	}
+}
+
+type ModifyAlertTool struct{}
+
+func (*ModifyAlertTool) Tool() mcp.Tool {
+	options := append([]mcp.ToolOption{
+		mcp.WithDescription("Modify an existing Kite alert"),
+		mcp.WithString("uuid",
+			mcp.Description("Alert UUID"),
+			mcp.Required(),
+		),
+	}, alertToolFields()...)
+	return mcp.NewTool("modify_alert", options...)
+}
+
+func (*ModifyAlertTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "modify_alert")
+		args := request.GetArguments()
+		if err := ValidateRequired(args, "uuid"); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		uuid := SafeAssertString(args["uuid"], "")
+		params, err := buildAlertParams(args)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return handler.HandleAPICall(ctx, "modify_alert", func(session *kc.KiteSessionData) (interface{}, error) {
+			return session.Kite.Client.ModifyAlert(uuid, params)
+		})
+	}
+}
+
+type DeleteAlertsTool struct{}
+
+func (*DeleteAlertsTool) Tool() mcp.Tool {
+	return mcp.NewTool("delete_alerts",
+		mcp.WithDescription("Delete one or more Kite alerts by UUID"),
+		mcp.WithArray("uuids",
+			mcp.Description("Alert UUIDs to delete"),
+			mcp.Required(),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+	)
+}
+
+func (*DeleteAlertsTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handler.trackToolCall(ctx, "delete_alerts")
+		args := request.GetArguments()
+		if err := ValidateRequired(args, "uuids"); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		uuids := SafeAssertStringArray(args["uuids"])
+		if len(uuids) == 0 {
+			return mcp.NewToolResultError("At least one alert UUID must be specified"), nil
+		}
+
+		return handler.HandleAPICall(ctx, "delete_alerts", func(session *kc.KiteSessionData) (interface{}, error) {
+			if err := session.Kite.Client.DeleteAlerts(uuids...); err != nil {
+				return nil, err
+			}
+			return map[string]any{"deleted": uuids}, nil
+		})
+	}
+}

--- a/mcp/alerts_tools_test.go
+++ b/mcp/alerts_tools_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kiteconnect "github.com/zerodha/gokiteconnect/v4"
+)
+
+func TestBuildAlertParams(t *testing.T) {
+	baseArgs := map[string]interface{}{
+		"name":              "NIFTY 50 threshold",
+		"type":              "simple",
+		"lhs_exchange":      "INDICES",
+		"lhs_tradingsymbol": "NIFTY 50",
+		"lhs_attribute":     "LastTradedPrice",
+		"operator":          ">=",
+		"rhs_type":          "constant",
+		"rhs_constant":      27000.0,
+	}
+
+	t.Run("simple constant alert", func(t *testing.T) {
+		params, err := buildAlertParams(baseArgs)
+		require.NoError(t, err)
+		assert.Equal(t, "NIFTY 50 threshold", params.Name)
+		assert.Equal(t, kiteconnect.AlertType("simple"), params.Type)
+		assert.Equal(t, "INDICES", params.LHSExchange)
+		assert.Equal(t, "NIFTY 50", params.LHSTradingSymbol)
+		assert.Equal(t, kiteconnect.AlertOperator(">="), params.Operator)
+		assert.Equal(t, "constant", params.RHSType)
+		assert.Equal(t, 27000.0, params.RHSConstant)
+		assert.Nil(t, params.Basket)
+	})
+
+	t.Run("instrument rhs alert", func(t *testing.T) {
+		args := cloneArgs(baseArgs)
+		args["rhs_type"] = "instrument"
+		args["rhs_exchange"] = "NSE"
+		args["rhs_tradingsymbol"] = "INFY"
+		args["rhs_attribute"] = "LastTradedPrice"
+
+		params, err := buildAlertParams(args)
+		require.NoError(t, err)
+		assert.Equal(t, "instrument", params.RHSType)
+		assert.Equal(t, "NSE", params.RHSExchange)
+		assert.Equal(t, "INFY", params.RHSTradingSymbol)
+		assert.Equal(t, "LastTradedPrice", params.RHSAttribute)
+	})
+
+	t.Run("ato alert decodes basket", func(t *testing.T) {
+		args := cloneArgs(baseArgs)
+		args["type"] = "ato"
+		args["basket"] = `{"name":"alerts-basket","type":"alert","tags":[],"items":[{"type":"insert","tradingsymbol":"RELIANCE","exchange":"NSE","weight":10000,"params":{"transaction_type":"BUY","product":"CNC","order_type":"MARKET","validity":"DAY","quantity":1,"variety":"regular","tags":[]}}]}`
+
+		params, err := buildAlertParams(args)
+		require.NoError(t, err)
+		require.NotNil(t, params.Basket)
+		assert.Equal(t, "alerts-basket", params.Basket.Name)
+		require.Len(t, params.Basket.Items, 1)
+		assert.Equal(t, "RELIANCE", params.Basket.Items[0].TradingSymbol)
+		assert.Equal(t, "BUY", params.Basket.Items[0].Params.TransactionType)
+	})
+
+	t.Run("requires rhs instrument fields", func(t *testing.T) {
+		args := cloneArgs(baseArgs)
+		args["rhs_type"] = "instrument"
+
+		_, err := buildAlertParams(args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rhs_exchange")
+	})
+
+	t.Run("requires basket for ato", func(t *testing.T) {
+		args := cloneArgs(baseArgs)
+		args["type"] = "ato"
+
+		_, err := buildAlertParams(args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "basket")
+	})
+
+	t.Run("rejects invalid basket json", func(t *testing.T) {
+		args := cloneArgs(baseArgs)
+		args["type"] = "ato"
+		args["basket"] = "{bad-json"
+
+		_, err := buildAlertParams(args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "valid JSON")
+	})
+}
+
+func TestAlertToolsAreRegistered(t *testing.T) {
+	toolNames := map[string]bool{}
+	for _, tool := range GetAllTools() {
+		toolNames[tool.Tool().Name] = true
+	}
+
+	for _, name := range []string{"get_alerts", "get_alert", "get_alert_history", "create_alert", "modify_alert", "delete_alerts"} {
+		assert.True(t, toolNames[name], "expected %s to be registered", name)
+	}
+}
+
+func cloneArgs(args map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(args))
+	for key, value := range args {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -41,10 +41,18 @@ func GetAllTools() []Tool {
 		&LTPTool{},
 		&OHLCTool{},
 
+		// Tools for Kite alerts
+		&GetAlertsTool{},
+		&GetAlertTool{},
+		&GetAlertHistoryTool{},
+
 		// Tools that post data to Kite Connect
 		&PlaceOrderTool{},
 		&ModifyOrderTool{},
 		&CancelOrderTool{},
+		&CreateAlertTool{},
+		&ModifyAlertTool{},
+		&DeleteAlertsTool{},
 		&PlaceGTTOrderTool{},
 		&ModifyGTTOrderTool{},
 		&DeleteGTTOrderTool{},


### PR DESCRIPTION
Fixes #75 

## Summary
- Upgrade gokiteconnect to v4.4.0 to use the official Alerts API client support.
- Add MCP tools for listing, reading, creating, modifying, deleting, and fetching history for Kite alerts.
- Add validation/unit coverage for alert parameter construction and tool registration.

## Notes
Issue #75 also asks for watchlist create/update support, but Kite Connect does not currently expose market watchlist APIs publicly, so this PR implements the supported Alerts API surface only.

## Testing
- git diff --check
- go test ./... 