### PR TITLE
Clarify tradebook availability and current-day order/trade scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Want to use AI with your Kite trading account? Just add `https://mcp.kite.trade/
 ## Features
 
 - **Portfolio Management**: View holdings, positions, margins, and mutual fund investments
-- **Order Management**: Place, modify, and cancel orders with full order history
+- **Order Management**: Place, modify, and cancel orders, and inspect current-day order/trade activity
 - **GTT Orders**: Good Till Triggered order management
 - **Market Data Access**: Real-time quotes, historical data, OHLC data
 - **Pagination Support**: Automatic pagination for large datasets (holdings, orders, trades)
@@ -204,10 +204,11 @@ For other MCP-compatible clients, use the hosted endpoint `https://mcp.kite.trad
 - `place_order` - Place new orders
 - `modify_order` - Modify existing orders
 - `cancel_order` - Cancel orders
-- `get_orders` - List all orders
-- `get_trades` - Trading history
-- `get_order_history` - Order execution history
-- `get_order_trades` - Get trades for a specific order
+- `get_orders` - List current trading day's orders
+- `get_trades` - List current trading day's executed trades
+- `get_order_history` - Get status history for a specific current-day order
+- `get_order_trades` - Get trades for a specific current-day order
+- `get_tradebook` - Explain Kite tradebook availability and current-day alternatives
 
 ### GTT Orders
 

--- a/mcp/get_tools.go
+++ b/mcp/get_tools.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -106,12 +107,12 @@ type TradesTool struct{}
 
 func (*TradesTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_trades",
-		mcp.WithDescription("Get trading history. Supports pagination for large datasets."),
+		mcp.WithDescription("Get executed trades for the current trading day only. Kite Connect's trades endpoint is a transient intraday tradebook and does not return historical trades or all account transactions. Supports pagination for large datasets."),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
 		mcp.WithNumber("limit",
-			mcp.Description("Maximum number of trades to return. If not specified, returns all trades. When specified, response includes pagination metadata."),
+			mcp.Description("Maximum number of current-day trades to return. If not specified, returns all current-day trades. When specified, response includes pagination metadata."),
 		),
 	)
 }
@@ -136,12 +137,12 @@ type OrdersTool struct{}
 
 func (*OrdersTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_orders",
-		mcp.WithDescription("Get all orders. Supports pagination for large datasets."),
+		mcp.WithDescription("Get orders for the current trading day only, including open, pending, executed, cancelled, and rejected orders. Kite Connect's order book is transient and does not return historical orders across days. Supports pagination for large datasets."),
 		mcp.WithNumber("from",
 			mcp.Description("Starting index for pagination (0-based). Default: 0"),
 		),
 		mcp.WithNumber("limit",
-			mcp.Description("Maximum number of orders to return. If not specified, returns all orders. When specified, response includes pagination metadata."),
+			mcp.Description("Maximum number of current-day orders to return. If not specified, returns all current-day orders. When specified, response includes pagination metadata."),
 		),
 	)
 }
@@ -232,7 +233,7 @@ type OrderHistoryTool struct{}
 
 func (*OrderHistoryTool) Tool() mcp.Tool {
 	return mcp.NewTool("get_order_history",
-		mcp.WithDescription("Get order history for a specific order"),
+		mcp.WithDescription("Get status history for a specific current-day order. Requires an order_id and does not list historical orders across days."),
 		mcp.WithString("order_id",
 			mcp.Description("ID of the order to fetch history for"),
 			mcp.Required(),
@@ -261,5 +262,54 @@ func (*OrderHistoryTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
 
 			return handler.MarshalResponse(orderHistory, "get_order_history")
 		})
+	}
+}
+
+type TradebookAvailabilityTool struct{}
+
+type tradebookAvailabilityResponse struct {
+	Available           bool     `json:"available"`
+	Scope               string   `json:"scope"`
+	CurrentDayTools     []string `json:"current_day_tools"`
+	HistoricalDataTools  []string `json:"historical_data_tools"`
+	Message             string   `json:"message"`
+	RecommendedResponse string   `json:"recommended_response"`
+}
+
+func (*TradebookAvailabilityTool) Tool() mcp.Tool {
+	return mcp.NewTool("get_tradebook",
+		mcp.WithDescription("Explain whether Kite MCP can fetch a complete historical stock transaction tradebook. This tool does not call a Kite API endpoint; it reports that Kite Connect exposes only current-day orders/trades through this server and points to the available alternatives."),
+	)
+}
+
+func (*TradebookAvailabilityTool) Handler(manager *kc.Manager) server.ToolHandlerFunc {
+	handler := NewToolHandler(manager)
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if manager != nil {
+			handler.trackToolCall(ctx, "get_tradebook")
+		}
+
+		response := tradebookAvailabilityResponse{
+			Available: false,
+			Scope:     "Kite Connect does not expose an API endpoint through this server for fetching all historical stock transactions or the full account tradebook across days.",
+			CurrentDayTools: []string{
+				"get_orders: current trading day's orders only",
+				"get_trades: current trading day's executed trades only",
+				"get_order_history: status history for one current-day order_id",
+				"get_order_trades: trades for one current-day order_id",
+			},
+			HistoricalDataTools: []string{
+				"get_historical_data: historical OHLC candle data for an instrument, not account transactions",
+			},
+			Message:             "There is no Kite MCP tool that fetches all historical stock transactions or the complete tradebook. Use the current-day order/trade tools for intraday activity; use Kite/Console reports outside Kite Connect for historical contract notes, ledger, tax P&L, or full transaction history.",
+			RecommendedResponse: "No. Kite MCP cannot fetch your complete historical stock transaction tradebook. get_orders and get_trades cover only the current trading day, while get_order_history and get_order_trades require a specific current-day order_id.",
+		}
+
+		v, err := json.Marshal(response)
+		if err != nil {
+			return mcp.NewToolResultError("Failed to process tradebook availability response"), nil
+		}
+
+		return mcp.NewToolResultText(string(v)), nil
 	}
 }

--- a/mcp/get_tools_test.go
+++ b/mcp/get_tools_test.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderAndTradeToolsDescribeCurrentDayScope(t *testing.T) {
+	tests := []struct {
+		name string
+		tool Tool
+		want []string
+	}{
+		{
+			name: "get_trades",
+			tool: &TradesTool{},
+			want: []string{"current trading day only", "does not return historical trades"},
+		},
+		{
+			name: "get_orders",
+			tool: &OrdersTool{},
+			want: []string{"current trading day only", "does not return historical orders"},
+		},
+		{
+			name: "get_order_history",
+			tool: &OrderHistoryTool{},
+			want: []string{"specific current-day order", "does not list historical orders across days"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			description := strings.ToLower(tt.tool.Tool().Description)
+			for _, want := range tt.want {
+				assert.Contains(t, description, strings.ToLower(want))
+			}
+		})
+	}
+}
+
+func TestTradebookAvailabilityToolRegistered(t *testing.T) {
+	toolNames := make(map[string]bool)
+	for _, tool := range GetAllTools() {
+		toolNames[tool.Tool().Name] = true
+	}
+
+	assert.True(t, toolNames["get_tradebook"])
+}
+
+func TestTradebookAvailabilityToolDescription(t *testing.T) {
+	tool := (&TradebookAvailabilityTool{}).Tool()
+
+	assert.Equal(t, "get_tradebook", tool.Name)
+	assert.Contains(t, strings.ToLower(tool.Description), "historical stock transaction tradebook")
+	assert.Contains(t, strings.ToLower(tool.Description), "only current-day orders/trades")
+}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -31,6 +31,7 @@ func GetAllTools() []Tool {
 		&OrdersTool{},
 		&OrderHistoryTool{},
 		&OrderTradesTool{},
+		&TradebookAvailabilityTool{},
 		&GTTOrdersTool{},
 		&MFHoldingsTool{},
 


### PR DESCRIPTION
Fixes #71

## Summary
- Clarifies that `get_orders`, `get_trades`, and order-specific tools only cover current-day Kite Connect data.
- Adds a `get_tradebook` informational tool so assistants can directly answer historical tradebook requests without overpromising unsupported API coverage.
- Updates README tool descriptions and adds unit coverage for the new/clarified tool metadata.

## Testing
- `git diff --check`
-  `go test ./...` 